### PR TITLE
Report which file not found in `module_file()`

### DIFF
--- a/R/module_file.r
+++ b/R/module_file.r
@@ -28,7 +28,7 @@ module_file = function (..., module = parent.frame(), mustWork = FALSE) {
         existing
     else
         if (mustWork)
-            stop('File not found: ', paths)
+            stop('File not found: ', sQuote(paths))
         else
             ''
 }

--- a/R/module_file.r
+++ b/R/module_file.r
@@ -28,7 +28,7 @@ module_file = function (..., module = parent.frame(), mustWork = FALSE) {
         existing
     else
         if (mustWork)
-            stop('no file found')
+            stop('File not found: ', paths)
         else
             ''
 }


### PR DESCRIPTION
Right now, `modules` will give the not-so-helpful error `no file found` when calling

```r
module_file("file_that_does_not_exist", mustWork=TRUE)
```

> no file found

It would be easier to track down errors using this function if it reported which file was not found. Using this patch, the function will report:

> File not found: /path/to/file_that_does_not_exist