### PR TITLE
Fix function in call is S3 matching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
     * Dispatch calls to `` `?` `` and `help` to devtools, if necessary (#34)
     * Run `document` twice to ensure S3 exports are correctly generated (#117,
       hadley/devtools#1585)
+    * Fix crash in S3 recognition when function bodies have been substituted at
+      runtime (#125)
 
 * 0.9.8:
     * Fix missing S3 methods bug (#117)

--- a/R/S3.r
+++ b/R/S3.r
@@ -44,6 +44,8 @@ is_S3_user_generic = function (function_name, envir = parent.frame()) {
     is_S3 = function (b) {
         if (length(b) == 0)
             return(FALSE)
+        if (is.function(b))
+            b = body(b)
         if (is.call(b)) {
             if (is.name(b[[1]]) && b[[1]] == 'UseMethod')
                 return(TRUE)

--- a/tests/testthat/modules/issue125.r
+++ b/tests/testthat/modules/issue125.r
@@ -1,0 +1,5 @@
+f = function () NULL
+body(f) = substitute(
+    do.call(g, list()),
+    list(g = function () 1)
+)

--- a/tests/testthat/test-S3.r
+++ b/tests/testthat/test-S3.r
@@ -61,3 +61,7 @@ test_that('Forwarded S3 genetics without methods work', {
     expect_that(s3_b$test(1), equals('test.default'))
     expect_that(s3_b$test('a'), equals('test.character'))
 })
+
+test_that('`is_S3_user_generic` can deal with substituted functions', {
+    expect_error(import('issue125'), regexp = NA)
+})


### PR DESCRIPTION
If `b` is a `do.call(function(...))`, the `is_S3_user_generic` will check a `function` in the next recursion.
Because this can not be indexed by `b[[1]]`, we get the following error:

> Error in b[[1]] : object of type 'closure' is not subsettable

The PR additionally checks if `b` is a function, and gets its body if it is.

Alternatively, if `b` is a `call` and *not* S3, do we *need* to check its contents for S3?