### PR TITLE
Fix tests

### DIFF
--- a/tests/testthat/helper-expect.r
+++ b/tests/testthat/helper-expect.r
@@ -1,7 +1,7 @@
 # Set up local module environment to test against.
 # Note that we override the normal path here.
 
-mod::set_options(path = 'modules')
+set_options(path = 'modules')
 
 expect_not_identical = function (object, expected, info = NULL, label = NULL, expected.label = NULL) {
     lab_act = testthat::quasi_label(rlang::enquo(object), label)

--- a/tests/testthat/helper-expect.r
+++ b/tests/testthat/helper-expect.r
@@ -1,7 +1,7 @@
 # Set up local module environment to test against.
 # Note that we override the normal path here.
 
-set_options(path = 'modules')
+mod::set_options(path = 'modules')
 
 expect_not_identical = function (object, expected, info = NULL, label = NULL, expected.label = NULL) {
     lab_act = testthat::quasi_label(rlang::enquo(object), label)

--- a/tests/testthat/test-pkg.r
+++ b/tests/testthat/test-pkg.r
@@ -110,12 +110,12 @@ test_that('wildcard attachments can contain aliases', {
     # Attach everything, and give some names aliases
     devtools_exports = getNamespaceExports('devtools')
     expected = c(
-        setdiff(devtools_exports, c('test', 'load_data')),
-        'test_alias', 'ld',
+        setdiff(devtools_exports, c('test', 'r_env_vars')),
+        'test_alias', 'ev',
         'devtools_exports', 'expected'
     )
     expect_length(ls(), 2L) # = `devtools_exports`, `expected`
-    mod::use(devtools[..., test_alias = test, ld = load_data])
+    mod::use(devtools[..., test_alias = test, ev = r_env_vars])
     expect_equal(length(ls()), length(expected))
     expect_false(any(is.na(match(ls(), expected))))
 })
@@ -127,8 +127,8 @@ test_that('non-existent aliases raise error', {
 })
 
 test_that('only exported things can be attached', {
-    expect_in('register_s3', ls(getNamespace('devtools')))
-    expect_error(mod::use(devtools[register_s3]), 'not exported')
+    expect_in('indent', ls(getNamespace('devtools')))
+    expect_error(mod::use(devtools[indent]), 'not exported')
 })
 
 test_that('packages that attach things are not aliased', {


### PR DESCRIPTION
devtool>=2 no longer has `load_data`, `register_s3 methods`
`make test` does not require `mod` to be installed, can not reference it by namespace

works for `make test` but not `make check` (broken vignettes)