### PR TITLE
Fix getting script_path from commandArgs()

### DIFF
--- a/R/module_cache.r
+++ b/R/module_cache.r
@@ -131,11 +131,11 @@ script_path = function () {
 
     args = commandArgs()
 
-    file_arg = grep('--file=', args)
+    file_arg = grep('^--file=', args)
     if (length(file_arg) != 0)
         return(dirname(sub('--file=', '', args[file_arg])))
 
-    f_arg = grep('-f', args)
+    f_arg = grep('^-f$', args)
     if (length(f_arg) != 0)
         return(dirname(args[f_arg + 1]))
 


### PR DESCRIPTION
Before, an argument like `R -e 'f <- 2; 1-f'` would break because “-f” is contained.